### PR TITLE
feat: Add 3-day weather forecast section

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,12 @@
   <img id="icon" alt="">
 
 </div>
+<!-- 3-Day Forecast Section -->
+  <div id="forecast-container">
+    <h3 id="forecast-title"></h3>
+    <div id="forecast-cards"></div>
+  </div>
+
 
 <script src="script.js"></script>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "weather",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/script.js
+++ b/script.js
@@ -21,9 +21,10 @@ function getWeather() {
     query = city + ",IN";
   }
 
-  const url = `https://api.weatherapi.com/v1/current.json?key=${apiKey}&q=${encodeURIComponent(query)}`;
+ const url = `https://api.weatherapi.com/v1/current.json?key=${apiKey}&q=${encodeURIComponent(query)}`;
+const forecastUrl = `https://api.weatherapi.com/v1/forecast.json?key=${apiKey}&q=${encodeURIComponent(query)}&days=5`;
 
-  fetch(url)
+ fetch(url)
     .then(res => res.json())
     .then(data => {
       if (data.error) {
@@ -35,8 +36,15 @@ function getWeather() {
     .catch(() => {
       alert("Failed to fetch weather data");
     });
-}
 
+  fetch(forecastUrl)
+    .then(res => res.json())
+    .then(data => {
+      if (!data.error) {
+        updateForecast(data);
+      }
+    });
+  }
 // 🔹 UPDATE UI FUNCTION
 function updateWeather(data) {
   currentData = data;
@@ -61,6 +69,40 @@ function updateWeather(data) {
     "https:" + data.current.condition.icon;
 }
 
+// 🔹 FORECAST FUNCTION
+function updateForecast(data) {
+  const forecastCards = document.getElementById("forecast-cards");
+  const forecastTitle = document.getElementById("forecast-title");
+
+  forecastTitle.innerText = "3-Day Forecast";
+  forecastCards.innerHTML = "";
+
+  data.forecast.forecastday.forEach(day => {
+    let high, low;
+
+    if (currentUnit === "C") {
+      high = Math.round(day.day.maxtemp_c) + "°C";
+      low = Math.round(day.day.mintemp_c) + "°C";
+    } else {
+      high = Math.round(day.day.maxtemp_f) + "°F";
+      low = Math.round(day.day.mintemp_f) + "°F";
+    }
+
+    const date = new Date(day.date);
+    const dayName = date.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+
+    const card = document.createElement("div");
+    card.classList.add("forecast-card");
+    card.innerHTML = `
+      <p class="forecast-day">${dayName}</p>
+      <img src="https:${day.day.condition.icon}" alt="${day.day.condition.text}" />
+      <p class="forecast-condition">${day.day.condition.text}</p>
+      <p class="forecast-temp">⬆ ${high} &nbsp; ⬇ ${low}</p>
+    `;
+    forecastCards.appendChild(card);
+  });
+}
+
 // 🔹 ENTER KEY SEARCH
 document.getElementById("city").addEventListener("keypress", function (e) {
   if (e.key === "Enter") {
@@ -75,8 +117,9 @@ function showPosition(position) {
   const lat = position.coords.latitude;
   const lon = position.coords.longitude;
 
-  const url = `https://api.weatherapi.com/v1/current.json?key=${apiKey}&q=${lat},${lon}`;
-
+const url = `https://api.weatherapi.com/v1/current.json?key=${apiKey}&q=${lat},${lon}`;
+  const forecastUrl = `https://api.weatherapi.com/v1/forecast.json?key=${apiKey}&q=${lat},${lon}&days=5`;
+ 
   fetch(url)
     .then(res => res.json())
     .then(data => {
@@ -97,6 +140,15 @@ document.getElementById("unit-toggle").addEventListener("click", function () {
   }
 
   updateWeather(currentData);
+
+  const city = document.getElementById("city").value.trim() ||
+    `${currentData.location.lat},${currentData.location.lon}`;
+  const forecastUrl = `https://api.weatherapi.com/v1/forecast.json?key=${apiKey}&q=${encodeURIComponent(city)}&days=5`;
+  fetch(forecastUrl)
+    .then(res => res.json())
+    .then(data => {
+      if (!data.error) updateForecast(data);
+    });
 });
 
 // 🌙 DARK MODE
@@ -118,3 +170,4 @@ themeBtn.addEventListener("click", () => {
     localStorage.setItem("theme", "light");
   }
 });
+

--- a/style.css
+++ b/style.css
@@ -157,6 +157,58 @@ body.dark-mode #theme-toggle {
   color: #fff;
 }
 
+/*FORECAST SECTION*/
+
+#forecast-container{
+  margin-top: 40px;
+  padding-bottom: 40px;
+}
+#forecast-title{
+  font-size:22px;
+  margin-bottom:20px;
+}
+
+#forecast-cards{
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap:15px;
+}
+
+.forecast-card{
+   background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(10px);
+  border-radius: 16px;
+  padding: 16px 20px;
+  width: 130px;
+  text-align: center;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s ease;
+}
+.forecast-card:hover {
+  transform: translateY(-5px);
+}
+
+.forecast-day {
+  font-weight: bold;
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+
+.forecast-condition {
+  font-size: 12px;
+  margin: 6px 0;
+}
+
+.forecast-temp {
+  font-size: 13px;
+  font-weight: bold;
+}
+
+.forecast-card img {
+  width: 50px;
+}
+
 /* 🌙 FORCE DARK MODE */
 body.dark-mode {
   background: #000000 !important;
@@ -204,5 +256,13 @@ body.dark-mode {
     right: 10px;
     padding: 6px 10px;
     font-size: 12px;
+  }
+   #forecast-cards {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .forecast-card {
+    width: 80%;
   }
 }


### PR DESCRIPTION
## Description
Adds a 3-day weather forecast section to the Weather Dashboard.

## Changes Made
- Added forecast API call using WeatherAPI's `/forecast` endpoint
- Created dynamic `ForecastCard` components showing day, icon, condition, and high/low temps
- Forecast temperatures sync with the existing °C / °F unit toggle
- Added glassmorphism styling for forecast cards matching the existing UI
- Fully responsive for mobile and desktop

<img width="1421" height="543" alt="image" src="https://github.com/user-attachments/assets/addafaf4-59ba-40be-af15-0acd94cd6019" />

## Checklist
-  Existing features are not affected
-  API integration is consistent with current setup
-  Responsive on mobile and desktop