### PR TITLE
fix: remove default country code and improve global city search accuracy

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,12 +14,7 @@ function getWeather() {
 
   let query;
 
-  // ✅ Fix: default country handling
-  if (city.includes(",")) {
-    query = city;
-  } else {
-    query = city + ",IN";
-  }
+  query=city;
 
   const url = `https://api.weatherapi.com/v1/current.json?key=${apiKey}&q=${encodeURIComponent(query)}`;
 
@@ -105,7 +100,7 @@ cityInput.addEventListener("input", function() {
                         const li = document.createElement("li");
                         li.textContent = `${location.name}, ${location.country}`;
                         li.addEventListener("click", () => {
-                            cityInput.value = location.name;
+                            cityInput.value = `${location.name}, ${location.country}`;
                             suggestionsList.style.display = "none";
                             getWeather();
                         });


### PR DESCRIPTION
### Fix: Improve global city search accuracy (Fixed #101)

**Description:**
This PR removes the default country code (`,IN`) from the API query to ensure accurate weather results for global cities.

**Issue:**
Previously, the app appended a default country code when a city was entered without specifying a country. This caused incorrect or misleading results for cities outside India (e.g., "Dubai" resolving incorrectly).

**Changes:**

* Removed hardcoded country (`",IN"`) from the query
* Ensured user input is passed directly to the API
* Updated autocomplete selection to include both city and country for better disambiguation

**Result:**

* Accurate results for global city searches
* No enforced country bias
* Improved reliability when selecting cities with the same name

**Testing:**

* Verified search works for cities like Dubai, London, Paris
* Checked autocomplete selection returns correct location
* Ensured existing features (unit toggle, geolocation, dark mode) remain unaffected

**Screenchots:**


<img width="943" height="662" alt="Screenshot 2026-05-04 155235" src="https://github.com/user-attachments/assets/e157ec63-a2b9-4113-9ed8-1cd496f793a4" />
<img width="892" height="651" alt="Screenshot 2026-05-04 155319" src="https://github.com/user-attachments/assets/7abaae16-81db-4751-8b55-734d40cd879e" />
<img width="933" height="638" alt="Screenshot 2026-05-04 155246" src="https://github.com/user-attachments/assets/9c117ff3-14c0-4d74-ab14-661aaf50a5ee" />
