### PR TITLE
feat: persist last searched city using localStorage #115

### DIFF
--- a/script.js
+++ b/script.js
@@ -29,6 +29,8 @@ function getWeather() {
         alert(data.error.message);
         return;
       }
+      
+      localStorage.setItem("lastSearchedCity", city);
       updateWeather(data);
     })
     .catch(() => {
@@ -132,8 +134,16 @@ document.getElementById("city").addEventListener("keypress", function (e) {
   }
 });
 
-// 🔹 AUTO GEOLOCATION ON PAGE LOAD (silent — no error shown to user)
-navigator.geolocation.getCurrentPosition(showPosition);
+// 🔹 INIT APP ON PAGE LOAD
+const lastCity = localStorage.getItem("lastSearchedCity");
+
+if (lastCity) {
+  document.getElementById("city").value = lastCity;
+  getWeather();
+} else {
+  // 🔹 AUTO GEOLOCATION ON PAGE LOAD (silent — no error shown to user)
+  navigator.geolocation.getCurrentPosition(showPosition);
+}
 
 function showPosition(position) {
   const lat = position.coords.latitude;


### PR DESCRIPTION
**What this PR does / why we need it:**
Resolves the issue where the weather application resets to a blank/geolocation state every time the user refreshes the page. By utilizing `localStorage`, the app now automatically remembers and fetches the last successfully searched city on page reload.

**Acceptance Criteria Met:**
- [x] Last searched city is restored automatically after a page reload.
- [x] `localStorage` is safely updated *only* after a successful API fetch.
- [x] Cleanly handles the "first visit" state (empty `localStorage`) by safely falling back to the default geolocation logic without console errors.
- [x] Invalid or failed searches are ignored and not saved.
- [x] No interference with the existing styling, Dark Mode, or user-triggered geolocation functionality.

**Changes Made:**
- Updated `script.js` to initialize the app by reading `lastSearchedCity` from `localStorage`.
- Added `localStorage.setItem` inside `getWeather()`, specifically placed after error-handling checks to guarantee data validity.

Closes #115 